### PR TITLE
Render widgets as expected on Django 1.11 [BP-12057]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ tests/tmp/
 *.coverage
 htmlcov/
 share/
+.idea/

--- a/phonenumber_field/widgets.py
+++ b/phonenumber_field/widgets.py
@@ -70,6 +70,14 @@ class PhoneNumberPrefixWidget(MultiWidget):
             return value.split('.')
         return [None, None]
 
+    def render(self, name, value, *args, **kwargs):
+        values = self.decompress(value)
+        rendered_widgets = [x.render('%s_%d' % (name, i),
+                                     values[i],
+                                     dict(self.attrs, **{'id': 'id_%s_%d' % (name, i)}))
+                            for i, x in enumerate(self.widgets)]
+        return ''.join(rendered_widgets)
+
     def value_from_datadict(self, data, files, name):
         values = super(PhoneNumberPrefixWidget, self).value_from_datadict(data, files, name)
         if not values[1]:


### PR DESCRIPTION
The bug has probably something to do with the newer version of Django. Composing widgets' render method just doesn't get called by a parent class anymore, so I had to add its own render method to our multi-widget. At least it works as expected this way.

Though, @sssbox , can you think of any better solution?